### PR TITLE
11 add proper state validation to all the createxjsx components

### DIFF
--- a/client/src/Components/UI/ConfirmRequest/ConfirmRequestForm.jsx
+++ b/client/src/Components/UI/ConfirmRequest/ConfirmRequestForm.jsx
@@ -64,51 +64,51 @@ const ConfirmRequestForm = (props) => {
       <ul className={classes.configs}>
         <FormConfigItem
           optionName="section"
-          inputs={configs.section}
           sendTo="section"
-          configs={configs}
+          isValid={sectionIsValid}
+          displayText={sectionDisplayText}
           setActiveConfig={setActiveConfig}
         />
         <FormConfigItem
           optionName="question type"
-          inputs={configs.questionTypes}
           sendTo="questions"
-          configs={configs}
+          isValid={questionTypeIsValid}
+          displayText={questionTypeDisplayText}
           setActiveConfig={setActiveConfig}
         />
         <FormConfigItem
           optionName="topics"
-          inputs={configs.passageTopics}
           sendTo="passages"
-          configs={configs}
+          isValid={topicsIsValid}
+          displayText={topicsDisplayText}
           setActiveConfig={setActiveConfig}
         />
         <FormConfigItem
           optionName="styles"
-          inputs={configs.passageStyles}
           sendTo="passages"
-          configs={configs}
+          isValid={stylesIsValid}
+          displayText={stylesDisplayText}
           setActiveConfig={setActiveConfig}
         />
         <FormConfigItem
           optionName="difficulty"
-          inputs={configs.difficulty}
           sendTo="extras"
-          configs={configs}
+          isValid={difficultyIsValid}
+          displayText={difficultyDisplayText}
           setActiveConfig={setActiveConfig}
         />
         <FormConfigItem
           optionName="number of questions"
-          inputs={configs.numberOfQuestions}
           sendTo="extras"
-          configs={configs}
+          isValid={questionNumberIsValid}
+          displayText={questionNumberDisplayText}
           setActiveConfig={setActiveConfig}
         />
         <FormConfigItem
           optionName="vocabulary"
-          inputs={configs.wordsToUse}
           sendTo="extras"
-          configs={configs}
+          isValid={vocabularyIsValid}
+          displayText={vocabularyDisplayText}
           setActiveConfig={setActiveConfig}
         />
       </ul>

--- a/client/src/Components/UI/ConfirmRequest/ConfirmRequestForm.jsx
+++ b/client/src/Components/UI/ConfirmRequest/ConfirmRequestForm.jsx
@@ -2,14 +2,38 @@ import React, { useContext, useState } from "react";
 import FormConfigItem from "../FormConfigItem/FormConfigItem";
 import Button from "../Button/Button";
 import ConfigContext from "../../../store/config-context";
+import useConfigValidator from "../../../hooks/use-config-validator";
 import classes from "./ConfirmRequestForm.module.css";
 
 const ConfirmRequestForm = (props) => {
   const { configs, setActiveConfig } = useContext(ConfigContext);
   const [isWaiting, setIsWaiting] = useState(false);
+  const validities = useConfigValidator(configs);
+  const {
+    sectionDisplayText,
+    sectionIsValid,
+    questionTypeDisplayText,
+    questionTypeIsValid,
+    topicsDisplayText,
+    topicsIsValid,
+    stylesDisplayText,
+    stylesIsValid,
+    difficultyDisplayText,
+    difficultyIsValid,
+    questionNumberDisplayText,
+    questionNumberIsValid,
+    vocabularyDisplayText,
+    vocabularyIsValid,
+  } = validities;
 
-  // error handling for items needs to be handled.
-  // disables button if any of the forms are invalid!
+  const allFieldsValid =
+    sectionIsValid &&
+    questionNumberIsValid &&
+    questionTypeIsValid &&
+    topicsIsValid &&
+    difficultyIsValid &&
+    vocabularyIsValid &&
+    stylesIsValid;
 
   // find a way to resize display text if it's above a certain size, probably in FormConfigItem.js
   const submitHandler = (event) => {
@@ -31,6 +55,9 @@ const ConfirmRequestForm = (props) => {
       }, 2000);
     }
   };
+
+  console.log(validities);
+  console.log(allFieldsValid);
 
   return (
     <form id="form" className={classes.form}>
@@ -93,6 +120,7 @@ const ConfirmRequestForm = (props) => {
         option="send"
         size="large"
         isWaiting={isWaiting}
+        disabled={!allFieldsValid}
       />
     </form>
   );

--- a/client/src/Components/UI/FormConfigItem/FormConfigItem.jsx
+++ b/client/src/Components/UI/FormConfigItem/FormConfigItem.jsx
@@ -7,32 +7,23 @@ const FormConfigItem = (props) => {
     props.setActiveConfig(location);
   };
 
-  let displayText = "";
-
-  if (props.inputs.constructor === Array) {
-    if (props.inputs.length > 1) {
-      for (let i = 0; i < props.inputs.length; i++) {
-        i === props.inputs.length - 1
-          ? (displayText += props.inputs[i])
-          : (displayText += `${props.inputs[i]}, `);
-      }
-    } else {
-      displayText = props.inputs.toString();
-    }
-  }
+  const itemStyling =
+    props.isValid === false
+      ? `${classes.item} ${classes["error-highlight"]}`
+      : classes.item;
 
   return (
-    <li className={classes.item}>
+    <li className={itemStyling}>
       <span className={classes["item-name"]}>{props.optionName}</span>
       <span className={classes.colon}>:</span>
       <span
         className={`${classes["item-value"]} ${
-          displayText.length > 20
+          props.displayText.length > 20
             ? classes["small-text"]
             : classes["large-text"]
         }`}
       >
-        {props.inputs.constructor === Array ? displayText : props.inputs}
+        {props.displayText}
       </span>
       <Button
         size="xsmall"

--- a/client/src/Components/UI/FormConfigItem/FormConfigItem.module.css
+++ b/client/src/Components/UI/FormConfigItem/FormConfigItem.module.css
@@ -10,6 +10,12 @@
   gap: 10px;
 }
 
+.error-highlight {
+  border-left: 4px solid var(--error);
+  padding-left: 12px;
+  border-radius: var(--rounded-lg);
+}
+
 .item-name {
   width: 150px;
   font-size: 2.8rem;

--- a/client/src/Components/UI/LoadingScreen/LoadingScreen.jsx
+++ b/client/src/Components/UI/LoadingScreen/LoadingScreen.jsx
@@ -45,7 +45,7 @@ const LoadingScreen = (props) => {
             size="medium"
             color="grey"
             option="go back"
-            onClick={() => console.log("clicked go back")}
+            onClick={() => window.location.reload()}
             disabled={isLoading}
           />
           <Button

--- a/client/src/hooks/use-config-validator.js
+++ b/client/src/hooks/use-config-validator.js
@@ -1,5 +1,3 @@
-import React, { useState, useReducer } from "react";
-
 const readingQuestionTypes = [
   "explicit meaning",
   "main idea",
@@ -37,24 +35,11 @@ const styleOptions = [
   "political",
 ];
 const difficultyOptions = ["varied", "easy", "medium", "hard"];
+const invalidString = "invalid entry";
 
 const useConfigValidator = (configs) => {
-  const validities = {
-    sectionDisplayText: "not selected",
-    sectionIsValid: false,
-    questionTypeDisplayText: "not selected",
-    questionTypeIsValid: false,
-    topicsDisplayText: "not selected",
-    topicsIsValid: false,
-    stylesDisplayText: "not selected",
-    stylesIsValid: false,
-    difficultyDisplayText: "not selected",
-    difficultyIsValid: false,
-    questionNumberDisplayText: "not selected",
-    questionNumberIsValid: false,
-    vocabularyDisplayText: "--",
-    vocabularyIsValid: true,
-  };
+  // deconstructs the configuration variable,
+  // allowing each of its properties to be read and validated.
   const {
     section,
     questionTypes,
@@ -64,122 +49,232 @@ const useConfigValidator = (configs) => {
     numberOfQuestions,
     wordsToUse,
   } = configs;
-  const invalid = "invalid entry";
 
-  // evaluates to see if section is valid.
-  if (section === "reading" || "writing") {
-    validities.sectionIsValid = true;
-    validities.sectionDisplayText = section;
-  } else {
-    validities.sectionIsValid = false;
-    validities.sectionDisplayText = invalid;
+  // parse all configs to make sure their data is valid.
+  const {
+    sectionIsValid,
+    sectionDisplayText,
+    questionTypeIsValid,
+    questionTypeDisplayText,
+  } = validateSectionAndQuestion(section, questionTypes);
+
+  const { topicsIsValid, topicsDisplayText } =
+    validatePassageTopics(passageTopics);
+
+  const { stylesIsValid, stylesDisplayText } =
+    validatePassageStyles(passageStyles);
+
+  const { difficultyIsValid, difficultyDisplayText } =
+    validateDifficulty(difficulty);
+
+  const { questionNumberIsValid, questionNumberDisplayText } =
+    validateQuestionNum(numberOfQuestions);
+
+  const { vocabularyIsValid, vocabularyDisplayText } =
+    validateVocabulary(wordsToUse);
+
+  return {
+    sectionIsValid,
+    sectionDisplayText,
+    questionTypeIsValid,
+    questionTypeDisplayText,
+    topicsIsValid,
+    topicsDisplayText,
+    stylesIsValid,
+    stylesDisplayText,
+    difficultyIsValid,
+    difficultyDisplayText,
+    questionNumberDisplayText,
+    questionNumberIsValid,
+    vocabularyIsValid,
+    vocabularyDisplayText,
+  };
+};
+
+const validateSectionAndQuestion = (section, questionTypes) => {
+  let sectionDisplayText = "not selected";
+  let sectionIsValid = false;
+  let questionTypeDisplayText = "not selected";
+  let questionTypeIsValid = false;
+
+  if (section === null) {
+    sectionIsValid = false;
+    sectionDisplayText = "not selected";
   }
 
-  // evaluates to see if questionTypes is valid.
-  if (questionTypes !== null && typeof questionTypes === "string") {
-    if (section === "reading") {
-      if (readingQuestionTypes.includes(questionTypes)) {
-        validities.questionTypeIsValid = true;
-        validities.questionTypeDisplayText = questionTypes;
-      } else {
-        validities.questionTypeIsValid = false;
-        validities.questionTypeDisplayText = invalid;
-      }
+  if (questionTypes === null) {
+    questionTypeIsValid = false;
+    questionTypeIsValid = "not selected";
+  }
+
+  if (typeof section !== "string" || typeof questionTypes !== "string") {
+    sectionIsValid = false;
+    sectionDisplayText = invalidString;
+    questionTypeIsValid = false;
+    questionTypeIsValid = invalidString;
+  }
+
+  if (typeof section === "string" && (section !== "reading" || "writing")) {
+    sectionIsValid = false;
+    sectionDisplayText = invalidString;
+  }
+
+  // happy path evaluation
+  if (section === "reading") {
+    if (readingQuestionTypes.includes(questionTypes)) {
+      sectionIsValid = true;
+      sectionDisplayText = section;
+      questionTypeIsValid = true;
+      questionTypeDisplayText = questionTypes;
+    } else {
+      sectionIsValid = false;
+      sectionDisplayText = section;
+      questionTypeIsValid = false;
+      questionTypeDisplayText = invalidString;
     }
-    if (section === "writing") {
-      if (writingQuestionTypes.includes(questionTypes)) {
-        validities.questionTypeIsValid = true;
-        validities.questionTypeDisplayText = questionTypes;
-      } else {
-        validities.questionTypeIsValid = false;
-        validities.questionTypeDisplayText = invalid;
-      }
+  }
+  if (section === "writing") {
+    if (writingQuestionTypes.includes(questionTypes)) {
+      sectionIsValid = true;
+      sectionDisplayText = section;
+      questionTypeIsValid = true;
+      questionTypeDisplayText = questionTypes;
+    } else {
+      sectionIsValid = false;
+      sectionDisplayText = section;
+      questionTypeIsValid = false;
+      questionTypeDisplayText = invalidString;
     }
   }
 
-  //evaluates to see if passageTopics is valid.
+  return {
+    sectionDisplayText,
+    sectionIsValid,
+    questionTypeDisplayText,
+    questionTypeIsValid,
+  };
+};
+
+const validatePassageTopics = (passageTopics) => {
+  let topicsDisplayText = "not selected";
+  let topicsIsValid = false;
+
   if (Object.prototype.toString.call(passageTopics) === "[object Array]") {
     const isContained = passageTopics.every((item) =>
       topicOptions.includes(item)
     );
     const containsVaried = passageTopics.includes("varied");
     if (isContained) {
-      validities.topicsIsValid = true;
-      validities.topicsDisplayText = containsVaried
-        ? "varied"
-        : passageTopics.join(", ");
+      topicsIsValid = true;
+      topicsDisplayText = containsVaried ? "varied" : passageTopics.join(", ");
     } else {
-      validities.topicsIsValid = false;
-      validities.topicsDisplayText = "invalid entry";
+      topicsIsValid = false;
+      topicsDisplayText = invalidString;
     }
   } else {
-    validities.topicsIsValid = false;
-    validities.topicsDisplayText = "invalid entry";
+    topicsIsValid = false;
+    topicsDisplayText = invalidString;
   }
 
-  //evaluates to see if passageStyles is valid.
+  return {
+    topicsDisplayText,
+    topicsIsValid,
+  };
+};
+
+const validatePassageStyles = (passageStyles) => {
+  let stylesIsValid = false;
+  let stylesDisplayText = "not selected";
+
   if (Object.prototype.toString.call(passageStyles) === "[object Array]") {
     const isContained = passageStyles.every((item) =>
       styleOptions.includes(item)
     );
     const containsVaried = passageStyles.includes("varied");
     if (isContained) {
-      validities.stylesIsValid = true;
-      validities.stylesDisplayText = containsVaried
-        ? "varied"
-        : passageStyles.join(", ");
+      stylesIsValid = true;
+      stylesDisplayText = containsVaried ? "varied" : passageStyles.join(", ");
     } else {
-      validities.stylesIsValid = false;
-      validities.stylesDisplayText = "invalid entry";
+      stylesIsValid = false;
+      stylesDisplayText = invalidString;
     }
   } else {
-    validities.stylesIsValid = false;
-    validities.stylesDisplayText = "invalid entry";
+    stylesIsValid = false;
+    stylesDisplayText = invalidString;
   }
 
-  // evaluates to see if difficulty is valid.
+  return {
+    stylesIsValid,
+    stylesDisplayText,
+  };
+};
+
+const validateDifficulty = (difficulty) => {
+  let difficultyIsValid = false;
+  let difficultyDisplayText = "not selected";
+
   if (Object.prototype.toString.call(difficulty) === "[object Array]") {
     const isContained = difficulty.every((item) =>
       difficultyOptions.includes(item)
     );
     const containsVaried = difficulty.includes("varied");
     if (isContained) {
-      validities.difficultyIsValid = true;
-      validities.difficultyDisplayText = containsVaried
-        ? "varied"
-        : difficulty.join(", ");
+      difficultyIsValid = true;
+      difficultyDisplayText = containsVaried ? "varied" : difficulty.join(", ");
     } else {
-      validities.difficultyIsValid = false;
-      validities.stylesDisplayText = "invalid entry";
+      difficultyIsValid = false;
+      difficultyDisplayText = invalidString;
     }
   } else {
-    validities.difficultyIsValid = false;
-    validities.difficultyDisplayText = "invalid entry";
+    difficultyIsValid = false;
+    difficultyDisplayText = invalidString;
   }
 
-  //evaluates to see if numberOfQuestions is valid.
-  if (numberOfQuestions === 5 || 10 || 15) {
-    validities.questionNumberIsValid = true;
-    validities.questionNumberDisplayText = numberOfQuestions;
+  return {
+    difficultyIsValid,
+    difficultyDisplayText,
+  };
+};
+
+const validateQuestionNum = (questionNum) => {
+  let questionNumberIsValid = false;
+  let questionNumberDisplayText = "not selected";
+
+  if (questionNum === 5 || questionNum === 10 || questionNum === 15) {
+    questionNumberIsValid = true;
+    questionNumberDisplayText = questionNum;
   } else {
-    validities.questionNumberIsValid = false;
-    validities.questionNumberDisplayText = "invalid entry";
+    questionNumberIsValid = false;
+    questionNumberDisplayText = invalidString;
   }
 
-  //evaluates to see if wordsToUse is valid
+  return {
+    questionNumberIsValid,
+    questionNumberDisplayText,
+  };
+};
+
+const validateVocabulary = (wordsToUse) => {
+  let vocabularyIsValid = false;
+  let vocabularyDisplayText = "--";
+
   if (Object.prototype.toString.call(wordsToUse) === "[object Array]") {
     if (wordsToUse.length === 0) {
-      validities.vocabularyIsValid = true;
-      validities.vocabularyDisplayText = "--";
+      vocabularyIsValid = true;
+      vocabularyDisplayText = "--";
     } else {
-      validities.vocabularyIsValid = true;
-      validities.vocabularyDisplayText = wordsToUse.join(", ");
+      vocabularyIsValid = true;
+      vocabularyDisplayText = wordsToUse.join(", ");
     }
   } else {
-    validities.vocabularyIsValid = false;
-    validities.vocabularyDisplayText = "error";
+    vocabularyIsValid = false;
+    vocabularyDisplayText = invalidString;
   }
-  return validities;
+
+  return {
+    vocabularyIsValid,
+    vocabularyDisplayText,
+  };
 };
 
 export default useConfigValidator;

--- a/client/src/hooks/use-config-validator.js
+++ b/client/src/hooks/use-config-validator.js
@@ -1,0 +1,185 @@
+import React, { useState, useReducer } from "react";
+
+const readingQuestionTypes = [
+  "explicit meaning",
+  "main idea",
+  "purpose",
+  "words in context",
+  "inference",
+  "organization",
+];
+const writingQuestionTypes = [
+  "supporting detail",
+  "YYNN",
+  "punctuation",
+  "parallelism",
+  "modifiers",
+  "verbs",
+  "word choice",
+  "organization",
+];
+const topicOptions = [
+  "varied",
+  "history",
+  "earth science",
+  "chemistry",
+  "social studies",
+  "psychology",
+  "literature",
+];
+const styleOptions = [
+  "varied",
+  "modern",
+  "argument",
+  "old (1900s)",
+  "old (1800s)",
+  "flowery",
+  "political",
+];
+const difficultyOptions = ["varied", "easy", "medium", "hard"];
+
+const useConfigValidator = (configs) => {
+  const validities = {
+    sectionDisplayText: "not selected",
+    sectionIsValid: false,
+    questionTypeDisplayText: "not selected",
+    questionTypeIsValid: false,
+    topicsDisplayText: "not selected",
+    topicsIsValid: false,
+    stylesDisplayText: "not selected",
+    stylesIsValid: false,
+    difficultyDisplayText: "not selected",
+    difficultyIsValid: false,
+    questionNumberDisplayText: "not selected",
+    questionNumberIsValid: false,
+    vocabularyDisplayText: "--",
+    vocabularyIsValid: true,
+  };
+  const {
+    section,
+    questionTypes,
+    passageTopics,
+    passageStyles,
+    difficulty,
+    numberOfQuestions,
+    wordsToUse,
+  } = configs;
+  const invalid = "invalid entry";
+
+  // evaluates to see if section is valid.
+  if (section === "reading" || "writing") {
+    validities.sectionIsValid = true;
+    validities.sectionDisplayText = section;
+  } else {
+    validities.sectionIsValid = false;
+    validities.sectionDisplayText = invalid;
+  }
+
+  // evaluates to see if questionTypes is valid.
+  if (questionTypes !== null && typeof questionTypes === "string") {
+    if (section === "reading") {
+      if (readingQuestionTypes.includes(questionTypes)) {
+        validities.questionTypeIsValid = true;
+        validities.questionTypeDisplayText = questionTypes;
+      } else {
+        validities.questionTypeIsValid = false;
+        validities.questionTypeDisplayText = invalid;
+      }
+    }
+    if (section === "writing") {
+      if (writingQuestionTypes.includes(questionTypes)) {
+        validities.questionTypeIsValid = true;
+        validities.questionTypeDisplayText = questionTypes;
+      } else {
+        validities.questionTypeIsValid = false;
+        validities.questionTypeDisplayText = invalid;
+      }
+    }
+  }
+
+  //evaluates to see if passageTopics is valid.
+  if (Object.prototype.toString.call(passageTopics) === "[object Array]") {
+    const isContained = passageTopics.every((item) =>
+      topicOptions.includes(item)
+    );
+    const containsVaried = passageTopics.includes("varied");
+    if (isContained) {
+      validities.topicsIsValid = true;
+      validities.topicsDisplayText = containsVaried
+        ? "varied"
+        : passageTopics.join(", ");
+    } else {
+      validities.topicsIsValid = false;
+      validities.topicsDisplayText = "invalid entry";
+    }
+  } else {
+    validities.topicsIsValid = false;
+    validities.topicsDisplayText = "invalid entry";
+  }
+
+  //evaluates to see if passageStyles is valid.
+  if (Object.prototype.toString.call(passageStyles) === "[object Array]") {
+    const isContained = passageStyles.every((item) =>
+      styleOptions.includes(item)
+    );
+    const containsVaried = passageStyles.includes("varied");
+    if (isContained) {
+      validities.stylesIsValid = true;
+      validities.stylesDisplayText = containsVaried
+        ? "varied"
+        : passageStyles.join(", ");
+    } else {
+      validities.stylesIsValid = false;
+      validities.stylesDisplayText = "invalid entry";
+    }
+  } else {
+    validities.stylesIsValid = false;
+    validities.stylesDisplayText = "invalid entry";
+  }
+
+  // evaluates to see if difficulty is valid.
+  if (Object.prototype.toString.call(difficulty) === "[object Array]") {
+    const isContained = difficulty.every((item) =>
+      difficultyOptions.includes(item)
+    );
+    const containsVaried = difficulty.includes("varied");
+    if (isContained) {
+      validities.difficultyIsValid = true;
+      validities.difficultyDisplayText = containsVaried
+        ? "varied"
+        : difficulty.join(", ");
+    } else {
+      validities.difficultyIsValid = false;
+      validities.stylesDisplayText = "invalid entry";
+    }
+  } else {
+    validities.difficultyIsValid = false;
+    validities.difficultyDisplayText = "invalid entry";
+  }
+
+  //evaluates to see if numberOfQuestions is valid.
+  if (numberOfQuestions === 5 || 10 || 15) {
+    validities.questionNumberIsValid = true;
+    validities.questionNumberDisplayText = numberOfQuestions;
+  } else {
+    validities.questionNumberIsValid = false;
+    validities.questionNumberDisplayText = "invalid entry";
+  }
+
+  //evaluates to see if wordsToUse is valid
+  if (Object.prototype.toString.call(wordsToUse) === "[object Array]") {
+    if (wordsToUse.length === 0) {
+      validities.vocabularyIsValid = true;
+      validities.vocabularyDisplayText = "--";
+    } else {
+      validities.vocabularyIsValid = true;
+      validities.vocabularyDisplayText = wordsToUse.join(", ");
+    }
+  } else {
+    validities.vocabularyIsValid = false;
+    validities.vocabularyDisplayText = "error";
+  }
+  return validities;
+};
+
+export default useConfigValidator;


### PR DESCRIPTION
created a custom hook in client/src/hooks/use-config-validator.js, which contains a script to deconstruct configs, read them, and return an object with state validities and "readable" values of those validities. this prevents the need for FormConfigItem to provide a one-stop solution to not crashing ConfirmRequestForm if the values in config are their initial values (null).

refactored FormConfigItem.jsx to highlight any erroneous configurations and removed its need to evaluate configuration validity. 

changed ConfirmRequestForm to disable the submission button if all fields are not valid.